### PR TITLE
ランキング表示を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# PHPStorm
+.idea*

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -48,11 +48,6 @@ body {
     color: #FA776D;
 }
 
-.modal-content {
-    background-color: #FFF4E1;
-    font-size: 20px;
-}
-
 /* For PC */
 @media screen and (min-width: 481px) {
     .canvas-parent {
@@ -87,3 +82,63 @@ body {
         font-size: 20px;
     }
 }
+
+.modal {
+    padding-top: 48px;
+}
+
+.modal-overlay {
+    box-shadow: 0 0 4px gray;
+}
+
+.modal-content {
+    background: #FFF4E1;
+    font-size: 20px;
+    width: 320px;
+}
+
+.modal-header {
+    border-bottom: 1px solid #d6d6d6;
+}
+
+.modal-footer {
+    border-top: 1px solid #d6d6d6;
+}
+
+.modal-score {
+    color: #FA776D;
+    text-align: right;
+    float: right;
+}
+
+.ranking {
+    padding: 12px auto;
+}
+
+.table {
+    font-size: 16px;
+    background: #fff;
+    counter-reset: rowCount;
+    color: #636363;
+}
+
+.table-bordered {
+    border-top: solid 1px #d6d6d6;
+}
+
+table > tbody > tr {
+    counter-increment: rowCount;
+}
+
+.table thead th {
+    border: solid 1px #d6d6d6;
+}
+
+.table > tbody > tr > td {
+    border: solid 1px #d6d6d6;
+}
+
+table > tbody > tr > td:first-child::before {
+    content: counter(rowCount);
+}
+

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -319,6 +319,7 @@
                     result.innerText = 'CLEAR!!';
                     document.getElementById("game-frame").style.zIndex = 100;
                     document.getElementById("clearModal").style.opacity = 1;
+                    document.getElementById("clearModal").style.backgroundColor = "rgb(0,0,0,0.5)";
                     document.getElementById("modalScore").innerText = scr;
                 }
             }

--- a/src/template/score-ranking.php
+++ b/src/template/score-ranking.php
@@ -1,16 +1,59 @@
 <div class="modal fade modal-dialog-centered" id="clearModal" tabindex="-1" role="dialog" aria-labelledby="clear-label" aria-hidden="true">
-    <div class="modal-dialog modal-xl" role="document">
+    <div class="modal-dialog" role="document">
         <div class="modal-overlay">
-            <div class="modal-content">
+            <div class="modal-content" id="modalContent">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="clear-label">CLEAR!!</h5>
+                    <h5 class="modal-title" id="clear-label">SCORE RESULT</h5>
                     <button type="button" class="close clear-modal-close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>
                 <div class="modal-body">
                     <div id="clearModalBody">
-                        <div>Your Score : <span id="modalScore"></span></div>
+                        <h4>Your Score : <div id="modalScore" class="modal-score"></div></h4>
+                    </div>
+                    <div class="clear-modal-body ranking">
+                        <?php
+                            include( __DIR__ . '/../util/api/Helper.php');
+                            $query = [
+                                    'sort' => 'score-',
+                                    'limit' => '10',
+                            ];
+                            $helper = Helper::getInstance($query);
+                            $score_history = $helper->get($query);
+                        ?>
+                        <table class="table table-sm table-bordered">
+                                <?php if (!empty($score_history)) { ?>
+                                <h5>SCORE RANKING</h5>
+                                <thead>
+                                    <tr align="center">
+                                        <th scope="col">RANK</th>
+                                        <th scope="col">NAME</th>
+                                        <th scope="col">SCORE</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach($score_history->scoreHistoryList as $key => $history): ?>
+                                        <tr>
+                                            <td scope="row" align="center"></td>
+                                            <td>
+                                                <?php
+                                                    $name = $history->guestName;
+                                                    if (!$name) {
+                                                        $name_list = ["Pikachu", "Fred", "Jonson", "Lombardi", "Laura", "Eliza", "Rosa", "Apple", "Peach", "Dr,MARIO"];
+                                                        $name_index = rand(0, count($name_list) - 1);
+                                                        $name = 'ナナシ_'.$name_list[$name_index];
+                                                    }
+                                                    echo $name;
+                                                ?>
+                                            </td>
+                                            <td align="right"><?php echo $history->score; ?></td>
+                                        </tr>
+                                    <?php endforeach;
+                                    }
+                                    ?>
+                                <tbody>
+                        </table>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/src/util/api/Config.php
+++ b/src/util/api/Config.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    'score_history' => [
+        'api-server' => 'http://host.docker.internal',
+        'port'       => '8880',
+        'get-uri'    => 'scorehistories',
+    ],
+];

--- a/src/util/api/Helper.php
+++ b/src/util/api/Helper.php
@@ -1,0 +1,66 @@
+<?php
+class Helper
+{
+    private $url;
+    private $config;
+
+    protected static $singleton;
+
+    protected function __construct()
+    {
+        $this->config = include(__DIR__ . '/Config.php');
+        $this->url    = $this->config['score_history']['api-server'].':'.$this->config['score_history']['port'];
+    }
+
+    public static function getInstance() {
+        if (!isset(self::$singleton)) {
+            self::$singleton = new Helper();
+        }
+        return self::$singleton;
+    }
+
+    /**
+     * @param  Array $query_params
+     * @return Array $score_history
+     */
+    public function get($query_params=null)
+    {
+        $url = $this->url.'/'.$this->config['score_history']['get-uri'];
+        $query = static::_generateQuery($query_params);
+        $url = $url.$query;
+
+        //cURLセッションを初期化する
+        $ch = curl_init();
+
+        //URLとオプションを指定する
+        curl_setopt($ch, CURLOPT_URL, $url);//取得するURL
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);//curl_exec()の返り値を文字列で返す。通常はデータを直接出力。
+
+        //URLの情報を取得し、ブラウザに渡す
+        $res =  curl_exec($ch);
+
+        //結果を表示する
+        $score_history = json_decode($res);
+
+        //セッションを終了する
+        curl_close($ch);
+        return $score_history;
+    }
+
+    private function _generateQuery($query_params)
+    {
+        $query = '';
+        if (!empty($query_params)) {
+            return $query;
+        }
+
+        foreach ($query_params as $key => $param) {
+            $concat = '&';
+            if (end($param)) {
+                $concat = '';
+            }
+            $query = $query.$key.'='.$param.$concat;
+        }
+        return '?'.$query;
+    }
+}


### PR DESCRIPTION
### 概要
ゲームクリア後にランキングを表示する。

### 変更点詳細
* .gitignoreにPHPStorm用の設定追加
* ゲーム終了後にスコアランキングを表示する
  * スコアの履歴はJavaAPIサーバから取得する
    * ref: https://qiita.com/ryo-futebol/items/6bdf503599a7c44b2f97
    * ref: https://qiita.com/kai_kou/items/5182965ea75c85cf1e3f
  * 接続先はConfigで設定