### PR TITLE
スマホでの中央寄せ

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -90,6 +90,7 @@ body {
 
 .modal {
     padding-top: 48px;
+    justify-content: center;
 }
 
 .modal-overlay {


### PR DESCRIPTION
## 概要
スマホで結果画面のmodalが左にずれていたので修正

|修正前|修正後|
|--|--|
|<img width="346" alt="image" src="https://user-images.githubusercontent.com/46984598/171184739-fd2069e6-544e-436d-8b64-47ea12850611.png">|<image src="https://user-images.githubusercontent.com/46984598/171184385-b11ff229-0a01-4fb3-9429-375ef5541caf.png" width=350>|


参考

[上下左右中央寄せ（ align-items と justyify-content ）](https://knowledge.cpi.ad.jp/tech/170/#:~:text=%E4%B8%8A%E4%B8%8B%E5%B7%A6%E5%8F%B3%E4%B8%AD%E5%A4%AE%E5%AF%84%E3%81%9B%EF%BC%88%20align%2Ditems%20%E3%81%A8%20justyify%2Dcontent%20%EF%BC%89)